### PR TITLE
Adding support for CPU sleep; battery (dis)charging rates; cellular traffic reported via rmnet_usb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# System Monitor for SailfishOS
+
+**NB!** This is a fork from custodian/harbour-systemmonitor with SysMon extensions developed for measuring stats related to battery monitoring.
+
+**NB!** Since the same database and the same service name are used as the one used by official SysMon, only one of these version can be installed at the same time.
+
+System Monitor records and shows your SailfishOS device usage detail stats.
+
+Currently you are able to see CPU, Battery and Traffic stats.
+
+There are several changes that I introduced into the excellent framework of System Monitor that allowed me to debug different issues in SailfishOS port. This package is made to share the changes with the hope that it would be useful for others as well. Note that this is unofficial version and some of these changes may not make it to the official SysMon.
+
+The main changes introduced in this unofficial build:
+
+*  Time spent by CPU in deep sleep is measured and reported
+*  Battery charging and discharging rate are calculated and displayed in Battery detailed statistics sheet
+*  Incompatible with official version! Traffic is reported as rates
+*  Reporting successful and failed suspend attempts
+*  Support for cell data statistics reported via /sys/class/net/rmnet_usb*, as in Nexus 4 port
+
+Details of the changes
+======================
+
+CPU sleep
+---------
+
+For each measuring interval, amount of time spent by CPU in deep sleep is measured. Then this time is related to real time difference in this interval and the deep sleep time is reported as a fraction of all time. Thus, if you ask SysMon to record the data every 2 minutes, this estimation would be done for time intervals of 2 minutes.
+
+When your device is not doing anything, screen is off, expect rather large fraction of time being spent in deep sleep (max I have seen is about 95%). During charging it is expected that deep sleep fraction is zero. By following deep sleep fraction you could see if your device is doing what is expected or there is some unexpected battery drain. As a part of CPU deep sleep details sheet, the statistics on amount of successful and failed suspend attempts are shown. 
+
+
+Battery charging and discharging rates
+--------------------------------------
+
+This information is helpful, but should be handled carefully due to calculation made to get the derivative. The options to change conditions for discharging rate are provided (accessible by touching discharging rate graph) and can be changed as required. There are surely better ways to calculate the rates from battery charge that could be implemented in future.
+
+
+Network traffic
+---------------
+
+**This change makes it incompatible with the database of the official version.** Please clear the database after moving between the versions in Settings menu!
+
+Instead of quantities, average rates within the measurement interval are reported. The same database IDs are used. As a result, data recorded by different versions are incompatible and would lead to erroneous plots in the app. So, if you wish to see correct statistics, you have to clear the database when you start using this version or would switch back to the official one.

--- a/app/app.pro
+++ b/app/app.pro
@@ -40,3 +40,6 @@ OTHER_FILES += \
     harbour-systemmonitor.desktop \
     harbour-systemmonitor.png
 
+DISTFILES += \
+    qml/pages/DerivativeSettings.qml
+

--- a/app/app.pro
+++ b/app/app.pro
@@ -41,5 +41,6 @@ OTHER_FILES += \
     harbour-systemmonitor.png
 
 DISTFILES += \
-    qml/pages/DerivativeSettings.qml
+    qml/pages/DerivativeSettings.qml \
+    qml/pages/CpuSleepPage.qml
 

--- a/app/qml/pages/AboutPage.qml
+++ b/app/qml/pages/AboutPage.qml
@@ -60,7 +60,7 @@ Page {
                 anchors.horizontalCenter: parent.horizontalCenter
                 color: Theme.primaryColor
                 font.pixelSize: Theme.fontSizeMedium
-                text: "<a href='#'>Web-site (OpenRepos)</a>";
+                text: "<a href='#'>Web-site (OpenRepos) of official version</a>";
                 linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally("https://openrepos.net/content/basil/system-monitor")
             }
@@ -68,7 +68,7 @@ Page {
                 anchors.horizontalCenter: parent.horizontalCenter
                 color: Theme.primaryColor
                 font.pixelSize: Theme.fontSizeMedium
-                text: "<a href='#'>Support forum (Talk Maemo Org)</a>";
+                text: "<a href='#'>Support forum (Talk Maemo Org) of official version</a>";
                 linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally("http://talk.maemo.org/showthread.php?t=93824")
             }
@@ -76,9 +76,17 @@ Page {
                 anchors.horizontalCenter: parent.horizontalCenter
                 color: Theme.primaryColor
                 font.pixelSize: Theme.fontSizeMedium
-                text: "<a href='#'>Source code (GitHub)</a>";
+                text: "<a href='#'>Source code (GitHub) of official version</a>";
                 linkColor: Theme.highlightColor
                 onLinkActivated: Qt.openUrlExternally("https://github.com/custodian/harbour-systemmonitor")
+            }
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                color: Theme.primaryColor
+                font.pixelSize: Theme.fontSizeMedium
+                text: "<a href='#'>Source code (GitHub) of this version</a>";
+                linkColor: Theme.highlightColor
+                onLinkActivated: Qt.openUrlExternally("https://github.com/rinigus/harbour-systemmonitor")
             }
             Text {
                 anchors.horizontalCenter: parent.horizontalCenter

--- a/app/qml/pages/AboutPage.qml
+++ b/app/qml/pages/AboutPage.qml
@@ -36,7 +36,7 @@ Page {
             Label {
                 x: Theme.paddingLarge
                 anchors.horizontalCenter: parent.horizontalCenter
-                text: APP_VERSION
+                text: APP_VERSION + " / Unofficial"
                 color: Theme.highlightColor
                 font.pixelSize: Theme.fontSizeSmall
             }

--- a/app/qml/pages/BatteryPage.qml
+++ b/app/qml/pages/BatteryPage.qml
@@ -17,6 +17,9 @@ Page {
 
     function updateGraph() {
         graphBattery.updateGraph();
+        graphCpuSleep.updateGraph();
+        graphBatteryDischarge.updateGraph();
+        graphBatteryCharge.updateGraph();
     }
 
     Connections {
@@ -75,6 +78,93 @@ Page {
                 dataDepth: deepView
                 minY: 0
                 maxY: 100
+                valueConverter: function(value) {
+                    return value.toFixed(2);
+                }
+
+                clickEnabled: false
+            }
+
+            SysMonGraph {
+                id: graphCpuSleep
+                graphTitle: qsTr("CPU sleep")
+                graphHeight: 200
+                dataType: [DataSource.CpuSleep]
+                dataAvg: true
+                dataDepth: deepView
+                minY: 0
+                maxY: 100
+                valueConverter: function(value) {
+                    return value.toFixed(2);
+                }
+
+                clickEnabled: false
+            }
+
+            SysMonGraph {
+                id: graphBatteryDischarge
+
+                graphTitle: qsTr("Battery discharging rate")
+                graphHeight: 200
+                dataType: [DataSource.BatteryPercentage]
+                dataAvg: true
+                dataDerivative: true
+                dataDerivativeTimeUnit: -3600.0
+                dataDerivativeMinDt: 900.0
+                dataDerivativeMinChange: 1.0
+                dataDepth: deepView
+                axisY.units: "% / h"
+                scale: false
+                maxY: 10
+                valueConverter: function(value) {
+                    return value.toFixed(2);
+                }
+
+                Component.onCompleted: {
+                    dataDerivativeMinDt = settings.batteryDischargeRateMinDt
+                    dataDerivativeMinChange = settings.batteryDischargeRateMinChange
+                    scale = settings.batteryDischargeRateAutoScale
+                    maxY = settings.batteryDischargeRateMaxY
+                }
+
+                Component.onDestruction: {
+                    settings.batteryDischargeRateMinDt = dataDerivativeMinDt
+                    settings.batteryDischargeRateMinChange = dataDerivativeMinChange
+                    settings.batteryDischargeRateAutoScale = scale
+                    settings.batteryDischargeRateMaxY = scale ? 10.0 : maxY
+                }
+
+                onClicked: {
+                    var dialog = pageStack.push( Qt.resolvedUrl("DerivativeSettings.qml"),
+                                                { "dialogTitle": "Battery discharging rate",
+                                                    "minDt": dataDerivativeMinDt,
+                                                    "minChange": dataDerivativeMinChange,
+                                                    "autoScale": scale,
+                                                    "maxY": maxY
+                                                })
+                    dialog.accepted.connect( function() {
+                        dataDerivativeMinDt = dialog.minDt
+                        dataDerivativeMinChange = dialog.minChange
+                        maxY = dialog.maxY
+                        scale = dialog.autoScale
+                        graphBatteryDischarge.updateGraph();
+                    } )
+                }
+            }
+
+            SysMonGraph {
+                id: graphBatteryCharge
+                graphTitle: qsTr("Battery charging rate")
+                graphHeight: 200
+                dataType: [DataSource.BatteryPercentage]
+                dataAvg: true
+                dataDerivative: true
+                dataDerivativeTimeUnit: 3600.0
+                dataDerivativeMinDt: 900.0
+                dataDerivativeMinChange: 1.0
+                dataDepth: deepView
+                axisY.units: "% / h"
+                scale: true
                 valueConverter: function(value) {
                     return value.toFixed(2);
                 }

--- a/app/qml/pages/BatteryPage.qml
+++ b/app/qml/pages/BatteryPage.qml
@@ -17,7 +17,7 @@ Page {
 
     function updateGraph() {
         graphBattery.updateGraph();
-        graphCpuSleep.updateGraph();
+//        graphCpuSleep.updateGraph();
         graphBatteryDischarge.updateGraph();
         graphBatteryCharge.updateGraph();
     }
@@ -86,22 +86,22 @@ Page {
                 clickEnabled: false
             }
 
-            SysMonGraph {
-                id: graphCpuSleep
-                graphTitle: qsTr("CPU sleep")
-                graphHeight: 200
-                dataType: [DataSource.CpuSleep]
-                dataAvg: true
-                dataDepth: deepView
-                axisY.units: "%"
-                minY: 0
-                maxY: 100
-                valueConverter: function(value) {
-                    return value.toFixed(0);
-                }
+//            SysMonGraph {
+//                id: graphCpuSleep
+//                graphTitle: qsTr("CPU sleep")
+//                graphHeight: 200
+//                dataType: [DataSource.CpuSleep]
+//                dataAvg: true
+//                dataDepth: deepView
+//                axisY.units: "%"
+//                minY: 0
+//                maxY: 100
+//                valueConverter: function(value) {
+//                    return value.toFixed(0);
+//                }
 
-                clickEnabled: false
-            }
+//                clickEnabled: false
+//            }
 
             SysMonGraph {
                 id: graphBatteryDischarge

--- a/app/qml/pages/BatteryPage.qml
+++ b/app/qml/pages/BatteryPage.qml
@@ -49,7 +49,7 @@ Page {
             width: page.width
             spacing: Theme.paddingLarge
             PageHeader {
-                title: qsTr("Battery statistics")
+                title: qsTr("Battery")
             }
 
             ComboBox {
@@ -76,10 +76,11 @@ Page {
                 dataType: [DataSource.BatteryPercentage]
                 dataAvg: true
                 dataDepth: deepView
+                axisY.units: "%"
                 minY: 0
                 maxY: 100
                 valueConverter: function(value) {
-                    return value.toFixed(2);
+                    return value.toFixed(0);
                 }
 
                 clickEnabled: false
@@ -92,10 +93,11 @@ Page {
                 dataType: [DataSource.CpuSleep]
                 dataAvg: true
                 dataDepth: deepView
+                axisY.units: "%"
                 minY: 0
                 maxY: 100
                 valueConverter: function(value) {
-                    return value.toFixed(2);
+                    return value.toFixed(0);
                 }
 
                 clickEnabled: false
@@ -113,7 +115,7 @@ Page {
                 dataDerivativeMinDt: 900.0
                 dataDerivativeMinChange: 1.0
                 dataDepth: deepView
-                axisY.units: "% / h"
+                axisY.units: qsTr(" [%/h]")
                 scale: false
                 maxY: 10
                 valueConverter: function(value) {
@@ -163,7 +165,7 @@ Page {
                 dataDerivativeMinDt: 900.0
                 dataDerivativeMinChange: 1.0
                 dataDepth: deepView
-                axisY.units: "% / h"
+                axisY.units: qsTr(" [%/h]")
                 scale: true
                 valueConverter: function(value) {
                     return value.toFixed(2);

--- a/app/qml/pages/CellPage.qml
+++ b/app/qml/pages/CellPage.qml
@@ -74,7 +74,7 @@ Page {
                 axisY.units: "Kb"
                 valueTotal: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(0);
+                    return (value/1000).toFixed(2);
                 }
 
                 clickEnabled: false
@@ -90,7 +90,7 @@ Page {
                 axisY.units: "Kb"
                 valueTotal: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(0);
+                    return (value/1000).toFixed(2);
                 }
 
                 clickEnabled: false

--- a/app/qml/pages/CellPage.qml
+++ b/app/qml/pages/CellPage.qml
@@ -71,10 +71,11 @@ Page {
                 dataType: [DataSource.NetworkCellRx]
                 dataDepth: deepView
                 scale: true
-                axisY.units: "Kb"
-                valueTotal: true
+                axisY.units: "kB/s"
+                //valueTotal: false
+                dataAvg: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(2);
+                    return (value/1000.).toFixed(2);
                 }
 
                 clickEnabled: false
@@ -87,10 +88,11 @@ Page {
                 dataType: [DataSource.NetworkCellTx]
                 dataDepth: deepView
                 scale: true
-                axisY.units: "Kb"
-                valueTotal: true
+                axisY.units: "kB/s"
+                //valueTotal: false
+                dataAvg: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(2);
+                    return (value/1000.).toFixed(2);
                 }
 
                 clickEnabled: false

--- a/app/qml/pages/CoverPage.qml
+++ b/app/qml/pages/CoverPage.qml
@@ -15,7 +15,7 @@ CoverBackground {
 
     function nextGraph() {
         needUpdate = true;
-        settings.coverGraphNum = (settings.coverGraphNum+1)%4
+        settings.coverGraphNum = (settings.coverGraphNum+1)%5
     }
 
     function updateGraph() {
@@ -57,6 +57,8 @@ CoverBackground {
                     return ramGraph;
                 case 3:
                     return batteryGraph;
+                case 4:
+                    return cpuSleepGraph;
 
                 }
             }
@@ -145,6 +147,26 @@ CoverBackground {
             graphTitle: qsTr("BAT")
             graphHeight: coverGraphHeight
             dataType: [DataSource.BatteryPercentage]
+            dataDepth: 1
+            dataAvg: true
+            axisX.grid: 1
+            minY: 0
+            maxY: 100
+            valueConverter: function(value) {
+                return value.toFixed(2);
+            }
+
+            clickEnabled: false
+        }
+    }
+
+    Component {
+        id: cpuSleepGraph
+
+        SysMonGraph {
+            graphTitle: qsTr("SLP")
+            graphHeight: coverGraphHeight
+            dataType: [DataSource.CpuSleep]
             dataDepth: 1
             dataAvg: true
             axisX.grid: 1

--- a/app/qml/pages/CoverPage.qml
+++ b/app/qml/pages/CoverPage.qml
@@ -153,7 +153,7 @@ CoverBackground {
             minY: 0
             maxY: 100
             valueConverter: function(value) {
-                return value.toFixed(2);
+                return value.toFixed(0);
             }
 
             clickEnabled: false
@@ -173,7 +173,7 @@ CoverBackground {
             minY: 0
             maxY: 100
             valueConverter: function(value) {
-                return value.toFixed(2);
+                return value.toFixed(0);
             }
 
             clickEnabled: false

--- a/app/qml/pages/CoverPage.qml
+++ b/app/qml/pages/CoverPage.qml
@@ -111,7 +111,7 @@ CoverBackground {
             dataDepth: 1
             scale: true
             axisX.grid: 1
-            axisY.units: "Kb"
+            axisY.units: "kB/s"
             valueConverter: function(value) {
                 return (value/1000).toFixed(0);
             }

--- a/app/qml/pages/CpuSleepPage.qml
+++ b/app/qml/pages/CpuSleepPage.qml
@@ -1,0 +1,120 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import net.thecust.sysmon 1.0
+
+Page {
+    id: page
+
+    property int deepView: 12
+    onDeepViewChanged: {
+        for (var i=0;i<depthModel.count;i++) {
+            if (depthModel.get(i).interval == deepView) {
+                comboBoxDepthView.currentIndex = i;
+                break;
+            }
+        }
+    }
+
+    function updateGraph() {
+        graphCpuSleep.updateGraph();
+        graphSuspendSuccess.updateGraph();
+        graphSuspendFail.updateGraph();
+    }
+
+    Connections {
+        target: sysmon
+        onDataUpdated: {
+            updateGraph();
+        }
+    }
+
+    Component.onCompleted: {
+        updateGraph();
+    }
+
+    SilicaFlickable {
+        id: flickable
+        anchors.fill: parent
+        contentHeight: column.height
+
+        VerticalScrollDecorator { flickable: flickable }
+
+        Column {
+            id: column
+
+            width: page.width
+            spacing: Theme.paddingLarge
+            PageHeader {
+                title: qsTr("CPU sleep statistics")
+            }
+
+            ComboBox {
+                id: comboBoxDepthView
+                label: qsTr("Show data for")
+                currentIndex: 2
+                menu: ContextMenu {
+                    Repeater {
+                        model: depthModel
+                        delegate: MenuItem {
+                            text: model.label
+                            onClicked: {
+                                page.deepView = model.interval
+                            }
+                        }
+                    }
+                }
+            }
+
+            SysMonGraph {
+                id: graphCpuSleep
+                graphTitle: qsTr("CPU sleep")
+                graphHeight: 200
+                dataType: [DataSource.CpuSleep]
+                dataAvg: true
+                dataDepth: deepView
+                axisY.units: "%"
+                minY: 0
+                maxY: 100
+                valueConverter: function(value) {
+                    return value.toFixed(2);
+                }
+
+                clickEnabled: false
+            }
+
+
+            SysMonGraph {
+                id: graphSuspendSuccess
+                graphTitle: qsTr("Suspend: success")
+                graphHeight: 200
+                dataType: [DataSource.SuspendSuccess]
+                dataAvg: true
+                dataDepth: deepView
+                axisY.units: "1 / h"
+                scale: true
+                valueConverter: function(value) {
+                    return (value * 3600).toFixed(2);
+                }
+
+                clickEnabled: false
+            }
+
+
+            SysMonGraph {
+                id: graphSuspendFail
+                graphTitle: qsTr("Suspend: failed")
+                graphHeight: 200
+                dataType: [DataSource.SuspendFail]
+                dataAvg: true
+                dataDepth: deepView
+                axisY.units: "1 / h"
+                scale: true
+                valueConverter: function(value) {
+                    return (value * 3600).toFixed(2);
+                }
+
+                clickEnabled: false
+            }
+        }
+    }
+}

--- a/app/qml/pages/CpuSleepPage.qml
+++ b/app/qml/pages/CpuSleepPage.qml
@@ -45,7 +45,7 @@ Page {
             width: page.width
             spacing: Theme.paddingLarge
             PageHeader {
-                title: qsTr("CPU sleep statistics")
+                title: qsTr("CPU sleep")
             }
 
             ComboBox {
@@ -76,7 +76,7 @@ Page {
                 minY: 0
                 maxY: 100
                 valueConverter: function(value) {
-                    return value.toFixed(2);
+                    return value.toFixed(0);
                 }
 
                 clickEnabled: false
@@ -90,10 +90,10 @@ Page {
                 dataType: [DataSource.SuspendSuccess]
                 dataAvg: true
                 dataDepth: deepView
-                axisY.units: "1 / h"
+                axisY.units: qsTr(" [1/h]")
                 scale: true
                 valueConverter: function(value) {
-                    return (value * 3600).toFixed(2);
+                    return (value * 3600).toFixed(0);
                 }
 
                 clickEnabled: false
@@ -107,10 +107,10 @@ Page {
                 dataType: [DataSource.SuspendFail]
                 dataAvg: true
                 dataDepth: deepView
-                axisY.units: "1 / h"
+                axisY.units: qsTr(" [1/h]")
                 scale: true
                 valueConverter: function(value) {
-                    return (value * 3600).toFixed(2);
+                    return (value * 3600).toFixed(0);
                 }
 
                 clickEnabled: false

--- a/app/qml/pages/DerivativeSettings.qml
+++ b/app/qml/pages/DerivativeSettings.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.0
+
+Item {
+
+}
+

--- a/app/qml/pages/DerivativeSettings.qml
+++ b/app/qml/pages/DerivativeSettings.qml
@@ -29,6 +29,7 @@ Dialog {
                 label: qsTr("Minimal time interval in seconds")
                 text: minDt
                 validator: DoubleValidator {}
+                inputMethodHints: Qt.ImhFormattedNumbersOnly
             }
 
             TextField {
@@ -37,6 +38,7 @@ Dialog {
                 label: qsTr("Minimal change in value")
                 text: minChange
                 validator: DoubleValidator {}
+                inputMethodHints: Qt.ImhFormattedNumbersOnly
             }
 
             TextSwitch {
@@ -52,6 +54,7 @@ Dialog {
                 label: qsTr("Maximal Y on graph")
                 text: maxY
                 validator: DoubleValidator {}
+                inputMethodHints: Qt.ImhFormattedNumbersOnly
             }
         }
     }

--- a/app/qml/pages/DerivativeSettings.qml
+++ b/app/qml/pages/DerivativeSettings.qml
@@ -1,6 +1,66 @@
 import QtQuick 2.0
+import Sailfish.Silica 1.0
 
-Item {
+Dialog {
+    property string dialogTitle: "Not Specified"
+    property var minDt: 900.0
+    property var minChange: 0.0
+    property var autoScale: true
+    property var maxY: 100.0
+
+    SilicaFlickable {
+        anchors.fill: parent
+
+        contentHeight: mainColumn.height
+
+        VerticalScrollDecorator {}
+
+        Column {
+            id: mainColumn
+            width: parent.width
+
+            DialogHeader {
+                title: dialogTitle
+            }
+
+            TextField {
+                id: valueMinDt
+                width: parent.width
+                label: qsTr("Minimal time interval in seconds")
+                text: minDt
+                validator: DoubleValidator {}
+            }
+
+            TextField {
+                id: valueMinChange
+                width: parent.width
+                label: qsTr("Minimal change in value")
+                text: minChange
+                validator: DoubleValidator {}
+            }
+
+            TextSwitch {
+                checked: autoScale
+                text: qsTr("Automatic scale for Y on graph")
+                description: autoScale ? qsTr("Scaled automatically") : qsTr("Scaled manually")
+                onClicked: autoScale = checked
+            }
+
+            TextField {
+                id: valueMaxY
+                width: parent.width
+                label: qsTr("Maximal Y on graph")
+                text: maxY
+                validator: DoubleValidator {}
+            }
+        }
+    }
+
+    onDone: {
+        if (valueMinDt.acceptableInput) minDt = parseFloat(valueMinDt.text)
+        if (valueMinChange.acceptableInput) minChange = parseFloat(valueMinChange.text)
+        if (valueMaxY.acceptableInput) maxY = parseFloat(valueMaxY.text)
+    }
 
 }
 

--- a/app/qml/pages/GraphData.qml
+++ b/app/qml/pages/GraphData.qml
@@ -259,9 +259,9 @@ Item {
                         if (!root.valueTotal) {
                             lastValue = points[end-1].y;
                         }
-                        if (lastValue) {
+                        //if (lastValue) {
                             labelLastValue.text = root.createYLabel(lastValue)+root.axisY.units;
-                        }
+                        //}
                     }
                 }
             }

--- a/app/qml/pages/MainPage.qml
+++ b/app/qml/pages/MainPage.qml
@@ -162,7 +162,7 @@ Page {
                 axisY.units: "Kb"
                 valueTotal: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(0);
+                    return (value/1000).toFixed(2);
                 }
 
                 onClicked: pageStack.push(Qt.resolvedUrl("CellPage.qml"), {deepView: settings.deepView})

--- a/app/qml/pages/MainPage.qml
+++ b/app/qml/pages/MainPage.qml
@@ -103,7 +103,7 @@ Page {
                 minY: 0
                 maxY: 100
                 valueConverter: function(value) {
-                    return value.toFixed(2);
+                    return value.toFixed(0);
                 }
 
                 onClicked: pageStack.push(Qt.resolvedUrl("BatteryPage.qml"), {deepView: settings.deepView})
@@ -164,7 +164,7 @@ Page {
                 //valueTotal: false
                 dataAvg: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(2);
+                    return (value/1000).toFixed(0);
                 }
 
                 onClicked: pageStack.push(Qt.resolvedUrl("WlanPage.qml"), {deepView: settings.deepView})
@@ -180,7 +180,7 @@ Page {
                 //valueTotal: false
                 dataAvg: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(2);
+                    return (value/1000).toFixed(0);
                 }
 
                 onClicked: pageStack.push(Qt.resolvedUrl("CellPage.qml"), {deepView: settings.deepView})

--- a/app/qml/pages/MainPage.qml
+++ b/app/qml/pages/MainPage.qml
@@ -144,10 +144,11 @@ Page {
                 graphHeight: 200
                 dataType: [DataSource.NetworkWlanRx, DataSource.NetworkWlanTx]
                 scale: true
-                axisY.units: "Kb"
-                valueTotal: true
+                axisY.units: "kB/s"
+                //valueTotal: false
+                dataAvg: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(0);
+                    return (value/1000).toFixed(2);
                 }
 
                 onClicked: pageStack.push(Qt.resolvedUrl("WlanPage.qml"), {deepView: settings.deepView})
@@ -159,8 +160,9 @@ Page {
                 graphHeight: 200
                 dataType: [DataSource.NetworkCellRx, DataSource.NetworkCellTx]
                 scale: true
-                axisY.units: "Kb"
-                valueTotal: true
+                axisY.units: "kB/s"
+                //valueTotal: false
+                dataAvg: true
                 valueConverter: function(value) {
                     return (value/1000).toFixed(2);
                 }

--- a/app/qml/pages/MainPage.qml
+++ b/app/qml/pages/MainPage.qml
@@ -27,6 +27,7 @@ Page {
             graphBattery.updateGraph();
             graphCpu.updateGraph();
             graphRam.updateGraph();
+            graphCpuSleep.updateGraph();
             graphWlanTotal.updateGraph();
             graphCellTotal.updateGraph();
             needUpdate = false;
@@ -136,6 +137,21 @@ Page {
                 }
 
                 onClicked: pageStack.push(Qt.resolvedUrl("RamPage.qml"), {deepView: settings.deepView})
+            }
+
+            SysMonGraph {
+                id: graphCpuSleep
+                graphTitle: qsTr("CPU sleep")
+                graphHeight: 200
+                dataType: [DataSource.CpuSleep]
+                dataAvg: true
+                minY: 0
+                maxY: 100
+                valueConverter: function(value) {
+                    return value.toFixed(0);
+                }
+
+                onClicked: pageStack.push(Qt.resolvedUrl("CpuSleepPage.qml"), {deepView: settings.deepView})
             }
 
             SysMonGraph {

--- a/app/qml/pages/SysMonGraph.qml
+++ b/app/qml/pages/SysMonGraph.qml
@@ -6,6 +6,10 @@ GraphData {
     property var dataType: []
     property int dataDepth: settings.deepView
     property bool dataAvg: false
+    property bool dataDerivative: false
+    property double dataDerivativeTimeUnit: 1.0
+    property double dataDerivativeMinDt: 60.0
+    property double dataDerivativeMinChange: 0.0
 
     onDataDepthChanged: {
         if (dataSource) {
@@ -20,6 +24,10 @@ GraphData {
 
     function updateGraph() {
         var dataPoints = dataSource.getSystemGraph(dataType, dataDepth, graphWidth, dataAvg);
+        if (dataDerivative) dataPoints = dataSource.calculateDerivative(dataPoints,
+                                                                        dataDerivativeTimeUnit,
+                                                                        dataDerivativeMinDt,
+                                                                        dataDerivativeMinChange);
         setPoints(dataPoints);
     }
 }

--- a/app/qml/pages/WlanPage.qml
+++ b/app/qml/pages/WlanPage.qml
@@ -71,10 +71,11 @@ Page {
                 dataType: [DataSource.NetworkWlanRx]
                 dataDepth: deepView
                 scale: true
-                axisY.units: "Kb"
-                valueTotal: true
+                axisY.units: "kB/s"
+                //valueTotal: false
+                dataAvg: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(0);
+                    return (value/1000.).toFixed(2);
                 }
 
                 clickEnabled: false
@@ -87,10 +88,11 @@ Page {
                 dataType: [DataSource.NetworkWlanTx]
                 dataDepth: deepView
                 scale: true
-                axisY.units: "Kb"
-                valueTotal: true
+                axisY.units: "kB/s"
+                //valueTotal: false
+                dataAvg: true
                 valueConverter: function(value) {
-                    return (value/1000).toFixed(0);
+                    return (value/1000.).toFixed(2);
                 }
 
                 clickEnabled: false

--- a/app/qml/sysmon.qml
+++ b/app/qml/sysmon.qml
@@ -18,6 +18,12 @@ ApplicationWindow
         property int coverGraphNum: 0
         property int updateInterval: 120
         property int archiveLength: 7
+
+        // settings used by battery discharge rate plot
+        property double batteryDischargeRateMinDt: 900.0
+        property double batteryDischargeRateMinChange: 1.0
+        property double batteryDischargeRateMaxY: 10.0
+        property bool batteryDischargeRateAutoScale: false
     }
 
     Component.onCompleted: {

--- a/app/systemmonitor.h
+++ b/app/systemmonitor.h
@@ -41,6 +41,8 @@ public slots:
 
     QVariant getSystemGraph(QVariantList types, int depth, int width, bool avg);
 
+    QVariantList calculateDerivative(QVariantList dataPoints, double timeUnit, double minDt, double minChange);
+
 private slots:
     void getUnitProperties();
     void onPropertiesChanged(QString interface, QMap<QString, QVariant> changed, QStringList invalidated);

--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -23,7 +23,8 @@ SOURCES += \
     datasourcewlan.cpp \
     datasourcecell.cpp \
     datasourcememory.cpp \
-    systemsnapshot.cpp
+    systemsnapshot.cpp \
+    datasourcecpusleep.cpp
 
 HEADERS += \
     settings.h \
@@ -37,7 +38,8 @@ HEADERS += \
     datasourcewlan.h \
     datasourcecell.h \
     datasourcememory.h \
-    systemsnapshot.h
+    systemsnapshot.h \
+    datasourcecpusleep.h
 
 #OTHER_FILES += \
 #    net.thecust.systemmonitord.xml

--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -24,7 +24,8 @@ SOURCES += \
     datasourcecell.cpp \
     datasourcememory.cpp \
     systemsnapshot.cpp \
-    datasourcecpusleep.cpp
+    datasourcecpusleep.cpp \
+    datasourcesuspend.cpp
 
 HEADERS += \
     settings.h \
@@ -39,7 +40,8 @@ HEADERS += \
     datasourcecell.h \
     datasourcememory.h \
     systemsnapshot.h \
-    datasourcecpusleep.h
+    datasourcecpusleep.h \
+    datasourcesuspend.h
 
 #OTHER_FILES += \
 #    net.thecust.systemmonitord.xml

--- a/daemon/datasource.cpp
+++ b/daemon/datasource.cpp
@@ -20,3 +20,8 @@ const QByteArray & DataSource::getSystemData(int source)
 {
     return m_snapshot->getSystemData(source);
 }
+
+const QDateTime & DataSource::getSnapshotTime() const
+{
+    return m_snapshot->getSnapshotTime();
+}

--- a/daemon/datasource.h
+++ b/daemon/datasource.h
@@ -31,7 +31,9 @@ public:
         NetworkCellTx,
         NetworkCellRx,
         BatteryPercentage = 400,
-        CpuSleep = 500
+        CpuSleep = 500,
+        SuspendSuccess = 600,
+        SuspendFail
     };
 
     DataSource(SystemSnapshot *parent = 0);

--- a/daemon/datasource.h
+++ b/daemon/datasource.h
@@ -45,6 +45,8 @@ protected:
     int registerApplicationSource(const QString &source);
 
     const QByteArray & getSystemData(int source);
+    const QDateTime& getSnapshotTime() const;
+
     //const QByteArray & getSystemData(const QString &source);
 
 private:

--- a/daemon/datasource.h
+++ b/daemon/datasource.h
@@ -30,7 +30,8 @@ public:
         NetworkWlanRx,
         NetworkCellTx,
         NetworkCellRx,
-        BatteryPercentage = 400
+        BatteryPercentage = 400,
+        CpuSleep = 500
     };
 
     DataSource(SystemSnapshot *parent = 0);

--- a/daemon/datasourcecell.cpp
+++ b/daemon/datasourcecell.cpp
@@ -8,20 +8,32 @@
 DataSourceCell::DataSourceCell(SystemSnapshot *parent) :
     DataSource(parent)
 {
-    QDir rmnet("/sys/class/net");
-    QStringList filters;
-    filters << "rmnet_usb*" << "rmnet?";
-    rmnet.setNameFilters(filters);
-
-    const QStringList files = rmnet.entryList();
-    QStringListIterator iterator(files);
-    QString fileName;
-    while ( iterator.hasNext() ) {
-        fileName = rmnet.absoluteFilePath(iterator.next());
-//        qDebug() << "Cell statistics:" << fileName;
-        m_sourcesRx.append(registerSystemSource(fileName + "/statistics/rx_bytes"));
-        m_sourcesTx.append(registerSystemSource(fileName + "/statistics/tx_bytes"));
+    for (int i=0;i<=7;i++) {
+        m_sourcesRx.append(registerSystemSource(QString("/sys/class/net/rmnet%1/statistics/rx_bytes").arg(i)));
+        m_sourcesRx.append(registerSystemSource(QString("/sys/class/net/rmnet_usb%1/statistics/rx_bytes").arg(i)));
+        m_sourcesTx.append(registerSystemSource(QString("/sys/class/net/rmnet%1/statistics/tx_bytes").arg(i)));
+        m_sourcesTx.append(registerSystemSource(QString("/sys/class/net/rmnet_usb%1/statistics/tx_bytes").arg(i)));
     }
+
+
+    // Solution below does not work on boot: rmnet_usb* dirs are not available on boot and come out
+    // after sysmon daemon start in Nexus 4
+
+//    QDir rmnet("/sys/class/net");
+//    QStringList filters;
+//    filters << "rmnet_usb*" << "rmnet?";
+//    rmnet.setNameFilters(filters);
+
+//    const QStringList files = rmnet.entryList();
+//    QStringListIterator iterator(files);
+//    QString fileName;
+//    while ( iterator.hasNext() ) {
+//        fileName = rmnet.absoluteFilePath(iterator.next());
+//        m_sourcesRx.append(registerSystemSource(fileName + "/statistics/rx_bytes"));
+//        m_sourcesTx.append(registerSystemSource(fileName + "/statistics/tx_bytes"));
+
+//        qDebug() << "Network cell data init: recording from " << fileName;
+//    }
 
     connect(parent, SIGNAL(processSystemSnapshot()), SLOT(processSystemSnapshot()));
 }

--- a/daemon/datasourcecell.cpp
+++ b/daemon/datasourcecell.cpp
@@ -68,8 +68,8 @@ void DataSourceCell::processSystemSnapshot()
     double rateRx = 0;
     double rateTx = 0;
 
-    if ( deltaRx > 0 ) rateRx = deltaRx / m_prevTime.secsTo(getSnapshotTime());
-    if ( deltaTx > 0 ) rateTx = deltaTx / m_prevTime.secsTo(getSnapshotTime());
+    if ( deltaRx > 0 ) rateRx = deltaRx / (double)m_prevTime.secsTo(getSnapshotTime());
+    if ( deltaTx > 0 ) rateTx = deltaTx / (double)m_prevTime.secsTo(getSnapshotTime());
 
     // storing old data
     m_prevBytesRx = bytesRx;

--- a/daemon/datasourcecell.cpp
+++ b/daemon/datasourcecell.cpp
@@ -71,6 +71,8 @@ void DataSourceCell::processSystemSnapshot()
     if ( deltaRx > 0 ) rateRx = deltaRx / (double)m_prevTime.secsTo(getSnapshotTime());
     if ( deltaTx > 0 ) rateTx = deltaTx / (double)m_prevTime.secsTo(getSnapshotTime());
 
+    //qDebug() << "Network CELL rates: " << rateRx << " " << rateTx << " [" << deltaRx << ", " << deltaTx << "]";
+
     // storing old data
     m_prevBytesRx = bytesRx;
     m_prevBytesTx = bytesTx;

--- a/daemon/datasourcecell.cpp
+++ b/daemon/datasourcecell.cpp
@@ -30,17 +30,17 @@ DataSourceCell::DataSourceCell(SystemSnapshot *parent) :
 void DataSourceCell::processSystemSnapshot()
 {
     //qDebug() << "Network CELL data";
-    int deltaRx = 0;
-    int deltaTx = 0;
+    long long deltaRx = 0;
+    long long deltaTx = 0;
 
-    QVector<int> bytesRx;
-    QVector<int> bytesTx;
+    QVector<unsigned long long> bytesRx;
+    QVector<unsigned long long> bytesTx;
     foreach(int sourceRx, m_sourcesRx) {
-        bytesRx.append(QString(getSystemData(sourceRx)).toInt());
+        bytesRx.append(QString(getSystemData(sourceRx)).toULongLong());
     }
 
     foreach(int sourceTx, m_sourcesTx) {
-        bytesTx.append(QString(getSystemData(sourceTx)).toInt());
+        bytesTx.append(QString(getSystemData(sourceTx)).toULongLong());
     }
 
     if (m_prevBytesRx.size() == bytesRx.size()) {
@@ -63,9 +63,19 @@ void DataSourceCell::processSystemSnapshot()
             }
         }
     }
+
+    // calculating rates
+    double rateRx = 0;
+    double rateTx = 0;
+
+    if ( deltaRx > 0 ) rateRx = deltaRx / m_prevTime.secsTo(getSnapshotTime());
+    if ( deltaTx > 0 ) rateTx = deltaTx / m_prevTime.secsTo(getSnapshotTime());
+
+    // storing old data
     m_prevBytesRx = bytesRx;
     m_prevBytesTx = bytesTx;
+    m_prevTime = getSnapshotTime();
 
-    emit systemDataGathered(DataSource::NetworkCellRx, deltaRx);
-    emit systemDataGathered(DataSource::NetworkCellTx, deltaTx);
+    emit systemDataGathered(DataSource::NetworkCellRx, rateRx);
+    emit systemDataGathered(DataSource::NetworkCellTx, rateTx);
 }

--- a/daemon/datasourcecell.cpp
+++ b/daemon/datasourcecell.cpp
@@ -1,13 +1,26 @@
 #include "datasourcecell.h"
 
 #include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QString>
 
 DataSourceCell::DataSourceCell(SystemSnapshot *parent) :
     DataSource(parent)
 {
-    for (int i=0;i<=7;i++) {
-        m_sourcesRx.append(registerSystemSource(QString("/sys/class/net/rmnet%1/statistics/rx_bytes").arg(i)));
-        m_sourcesTx.append(registerSystemSource(QString("/sys/class/net/rmnet%1/statistics/tx_bytes").arg(i)));
+    QDir rmnet("/sys/class/net");
+    QStringList filters;
+    filters << "rmnet_usb*" << "rmnet?";
+    rmnet.setNameFilters(filters);
+
+    const QStringList files = rmnet.entryList();
+    QStringListIterator iterator(files);
+    QString fileName;
+    while ( iterator.hasNext() ) {
+        fileName = rmnet.absoluteFilePath(iterator.next());
+//        qDebug() << "Cell statistics:" << fileName;
+        m_sourcesRx.append(registerSystemSource(fileName + "/statistics/rx_bytes"));
+        m_sourcesTx.append(registerSystemSource(fileName + "/statistics/tx_bytes"));
     }
 
     connect(parent, SIGNAL(processSystemSnapshot()), SLOT(processSystemSnapshot()));

--- a/daemon/datasourcecell.h
+++ b/daemon/datasourcecell.h
@@ -19,11 +19,12 @@ public slots:
     void processSystemSnapshot();
 
 private:
-    QVector<int> m_sourcesRx;
-    QVector<int> m_sourcesTx;
+    QVector<unsigned long long> m_sourcesRx;
+    QVector<unsigned long long> m_sourcesTx;
 
-    QVector<int> m_prevBytesRx;
-    QVector<int> m_prevBytesTx;
+    QDateTime m_prevTime;
+    QVector<unsigned long long> m_prevBytesRx;
+    QVector<unsigned long long> m_prevBytesTx;
 };
 
 #endif // DATASOURCECELL_H

--- a/daemon/datasourcecpusleep.cpp
+++ b/daemon/datasourcecpusleep.cpp
@@ -1,0 +1,7 @@
+#include "datasourcecpusleep.h"
+
+DataSourceCpuSleep::DataSourceCpuSleep()
+{
+
+}
+

--- a/daemon/datasourcecpusleep.cpp
+++ b/daemon/datasourcecpusleep.cpp
@@ -1,7 +1,36 @@
 #include "datasourcecpusleep.h"
 
-DataSourceCpuSleep::DataSourceCpuSleep()
-{
+#include <time.h>
+#include <QDebug>
 
+DataSourceCpuSleep::DataSourceCpuSleep(SystemSnapshot *parent) :
+    DataSource(parent)
+{
+    m_boot.tv_sec = 0;
+    m_boot.tv_nsec = 0;
+    m_mono.tv_sec = 0;
+    m_mono.tv_nsec = 0;
+
+    connect(parent, SIGNAL(processSystemSnapshot()), SLOT(processSystemSnapshot()));
 }
 
+void DataSourceCpuSleep::processSystemSnapshot()
+{
+    timespec b, m;
+    if ( clock_gettime(CLOCK_BOOTTIME, &b ) < 0 ||
+         clock_gettime(CLOCK_MONOTONIC, &m ) < 0)
+    {
+        qDebug() << "Data sleep: error getting one of the times";
+        return;
+    }
+
+    double db = b.tv_sec - m_boot.tv_sec + 1e-9 * (b.tv_nsec - m_boot.tv_nsec);
+    double dm = m.tv_sec - m_mono.tv_sec + 1e-9 * (m.tv_nsec - m_mono.tv_nsec);
+    double sleep = (db-dm) / db * 100;
+    qDebug() << "Sleep: " << dm << " / " << db << ": " << sleep;
+
+    m_boot = b;
+    m_mono = m;
+
+    emit systemDataGathered(DataSource::CpuSleep, sleep);
+}

--- a/daemon/datasourcecpusleep.cpp
+++ b/daemon/datasourcecpusleep.cpp
@@ -27,7 +27,7 @@ void DataSourceCpuSleep::processSystemSnapshot()
     double db = b.tv_sec - m_boot.tv_sec + 1e-9 * (b.tv_nsec - m_boot.tv_nsec);
     double dm = m.tv_sec - m_mono.tv_sec + 1e-9 * (m.tv_nsec - m_mono.tv_nsec);
     double sleep = (db-dm) / db * 100;
-    qDebug() << "Sleep: " << dm << " / " << db << ": " << sleep;
+    //qDebug() << "Sleep: " << dm << " / " << db << ": " << sleep;
 
     m_boot = b;
     m_mono = m;

--- a/daemon/datasourcecpusleep.h
+++ b/daemon/datasourcecpusleep.h
@@ -2,15 +2,24 @@
 #define DATASOURCECPUSLEEP_H
 
 #include <QObject>
+#include <time.h>
+
+#include "datasource.h"
+#include "systemsnapshot.h"
 
 class DataSourceCpuSleep : public DataSource
 {
-public:
-    DataSourceCpuSleep();
+    Q_OBJECT
 
-signals:
+public:
+    explicit DataSourceCpuSleep(SystemSnapshot *parent = 0);
 
 public slots:
+    void processSystemSnapshot();
+
+private:
+    timespec m_boot; ///< Previous reading of CLOCK_BOOTTIME
+    timespec m_mono; ///< Previous reading of CLOCK_MONOTONIC
 };
 
 #endif // DATASOURCECPUSLEEP_H

--- a/daemon/datasourcecpusleep.h
+++ b/daemon/datasourcecpusleep.h
@@ -1,0 +1,16 @@
+#ifndef DATASOURCECPUSLEEP_H
+#define DATASOURCECPUSLEEP_H
+
+#include <QObject>
+
+class DataSourceCpuSleep : public DataSource
+{
+public:
+    DataSourceCpuSleep();
+
+signals:
+
+public slots:
+};
+
+#endif // DATASOURCECPUSLEEP_H

--- a/daemon/datasourcesuspend.cpp
+++ b/daemon/datasourcesuspend.cpp
@@ -16,7 +16,7 @@ DataSourceSuspend::DataSourceSuspend(SystemSnapshot *parent):
 
 void DataSourceSuspend::processSystemSnapshot()
 {
-    qDebug() << "Suspend DATA";
+    //qDebug() << "Suspend DATA";
 
     QTextStream stat(getSystemData(m_suspendStat));
 
@@ -44,7 +44,7 @@ void DataSourceSuspend::processSystemSnapshot()
 
             double rate = (c-p) / (double)m_prevTime.secsTo(getSnapshotTime());
 
-            qDebug() << "Suspend: " << iter.key() << " " << p << "->" << c << " : " << rate;
+            //qDebug() << "Suspend: " << iter.key() << " " << p << "->" << c << " : " << rate;
 
             if (m_streams.contains(iter.key()) ) // must be always true
                 emit systemDataGathered( m_streams[iter.key()], rate);

--- a/daemon/datasourcesuspend.cpp
+++ b/daemon/datasourcesuspend.cpp
@@ -1,0 +1,58 @@
+#include "datasourcesuspend.h"
+#include "storage.h"
+
+#include <QTextStream>
+
+DataSourceSuspend::DataSourceSuspend(SystemSnapshot *parent):
+    DataSource(parent)
+{
+    m_suspendStat = registerSystemSource("/sys/kernel/debug/suspend_stats");
+
+    m_streams["success:"] = DataSource::SuspendSuccess;
+    m_streams["fail:"] = DataSource::SuspendFail;
+
+    connect(parent, SIGNAL(processSystemSnapshot()), SLOT(processSystemSnapshot()));
+}
+
+void DataSourceSuspend::processSystemSnapshot()
+{
+    qDebug() << "Suspend DATA";
+
+    QTextStream stat(getSystemData(m_suspendStat));
+
+    QMap< QString, unsigned long > current;
+
+    while ( !stat.atEnd() )
+    {
+        QString cline = stat.readLine();
+        if (cline.length() == 0) continue; // skip empty line
+
+        QStringList clist = cline.split(" ",QString::SkipEmptyParts);
+        if (clist.length() != 2) continue; // skip this line, it's not in form "key value"
+
+        if (m_streams.contains(clist[0])) current[ clist[0] ] = clist[1].toULong();
+    }
+
+    if ( m_prev.size() > 0 )
+    {
+        for ( QMap< QString, unsigned long >::const_iterator iter = current.constBegin();
+              iter != current.end();
+              ++iter )
+        {
+            unsigned long p = m_prev.value(iter.key());
+            unsigned long c = iter.value();
+
+            double rate = (c-p) / (double)m_prevTime.secsTo(getSnapshotTime());
+
+            qDebug() << "Suspend: " << iter.key() << " " << p << "->" << c << " : " << rate;
+
+            if (m_streams.contains(iter.key()) ) // must be always true
+                emit systemDataGathered( m_streams[iter.key()], rate);
+            else
+                qDebug() << "Internal error in DataSourceSuspend::processSystemSnapshot(): " << iter.key();
+        }
+    }
+
+    m_prevTime = getSnapshotTime();
+    m_prev = current;
+}

--- a/daemon/datasourcesuspend.h
+++ b/daemon/datasourcesuspend.h
@@ -1,0 +1,27 @@
+#ifndef DATASOURCESUSPEND_H
+#define DATASOURCESUSPEND_H
+
+#include <QObject>
+#include <QMap>
+#include "datasource.h"
+#include "systemsnapshot.h"
+
+class DataSourceSuspend:
+        public DataSource
+{
+    Q_OBJECT
+
+public:
+    DataSourceSuspend(SystemSnapshot *parent = 0);
+
+public slots:
+    void processSystemSnapshot();
+
+private:
+    int m_suspendStat;
+    QMap< QString, DataSource::Type > m_streams;
+    QMap< QString, unsigned long > m_prev;
+    QDateTime m_prevTime;
+};
+
+#endif // DATASOURCESUSPEND_H

--- a/daemon/datasourcewlan.cpp
+++ b/daemon/datasourcewlan.cpp
@@ -57,8 +57,8 @@ void DataSourceWlan::processSystemSnapshot()
     double rateRx = 0;
     double rateTx = 0;
 
-    if ( deltaRx > 0 ) rateRx = deltaRx / m_prevTime.secsTo(getSnapshotTime());
-    if ( deltaTx > 0 ) rateTx = deltaTx / m_prevTime.secsTo(getSnapshotTime());
+    if ( deltaRx > 0 ) rateRx = deltaRx / (double)m_prevTime.secsTo(getSnapshotTime());
+    if ( deltaTx > 0 ) rateTx = deltaTx / (double)m_prevTime.secsTo(getSnapshotTime());
 
     // storing old data
     m_prevBytesRx = bytesRx;

--- a/daemon/datasourcewlan.h
+++ b/daemon/datasourcewlan.h
@@ -22,8 +22,9 @@ private:
     int m_sourceRx;
     int m_sourceTx;
 
-    QVector<int> m_prevBytesRx;
-    QVector<int> m_prevBytesTx;
+    QDateTime m_prevTime;
+    QVector<unsigned long long> m_prevBytesRx;
+    QVector<unsigned long long> m_prevBytesTx;
 };
 
 #endif // DATASOURCEWLAN_H

--- a/daemon/service.cpp
+++ b/daemon/service.cpp
@@ -5,6 +5,7 @@
 #include "datasourcewlan.h"
 #include "datasourcememory.h"
 #include "datasourcecpusleep.h"
+#include "datasourcesuspend.h"
 
 Service::Service(QObject *parent, Settings *settings) :
     SystemSnapshot(parent), m_settings(settings)
@@ -31,6 +32,7 @@ void Service::initDataSources()
     m_sources.append(new DataSourceCell(this));
     m_sources.append(new DataSourceMemory(this));
     m_sources.append(new DataSourceCpuSleep(this));
+    m_sources.append(new DataSourceSuspend(this));
     //m_sources.append(new DataSourceTemp(this));
 
     foreach(const DataSource* source, m_sources) {

--- a/daemon/service.cpp
+++ b/daemon/service.cpp
@@ -4,6 +4,7 @@
 #include "datasourcecell.h"
 #include "datasourcewlan.h"
 #include "datasourcememory.h"
+#include "datasourcecpusleep.h"
 
 Service::Service(QObject *parent, Settings *settings) :
     SystemSnapshot(parent), m_settings(settings)
@@ -29,6 +30,7 @@ void Service::initDataSources()
     m_sources.append(new DataSourceWlan(this));
     m_sources.append(new DataSourceCell(this));
     m_sources.append(new DataSourceMemory(this));
+    m_sources.append(new DataSourceCpuSleep(this));
     //m_sources.append(new DataSourceTemp(this));
 
     foreach(const DataSource* source, m_sources) {

--- a/daemon/systemsnapshot.cpp
+++ b/daemon/systemsnapshot.cpp
@@ -37,6 +37,12 @@ const QByteArray& SystemSnapshot::getSystemData(int source)
     return *m_systemSnapshot.value(source, m_emptySource).data();
 }
 
+const QDateTime& SystemSnapshot::getSnapshotTime() const
+{
+    return m_snapshotTime;
+}
+
+
 void SystemSnapshot::makeSnapshot()
 {
     m_snapshotTime = QDateTime::currentDateTimeUtc();

--- a/daemon/systemsnapshot.h
+++ b/daemon/systemsnapshot.h
@@ -19,6 +19,7 @@ public:
     int registerApplicationSource(const QString &source);
 
     const QByteArray& getSystemData(int source);
+    const QDateTime& getSnapshotTime() const;
     //void getApplicationSnapshot();
 
 signals:

--- a/rpm/harbour-systemmonitor.changes
+++ b/rpm/harbour-systemmonitor.changes
@@ -8,6 +8,14 @@
 # * date Author's Name <author's email> version-release
 # - Summary of changes
 
+* Sun May 1 2016 rinigus <rinigus.git@gmail.com> 0.6-22
+- Forked after the merge of pull request #13 from abranson/master
+- Network traffic is reported in kB/s, as opposed to quantities used in official version
+- Battery discharging and charging rates are calculated from the battery percentage history
+- Reporting fraction of a time that CPU stayed in deep sleep, new cover and new detailed plot
+- Reporting successful and failed suspend attempts
+- Support for cell data statistics reported via /sys/class/net/rmnet_usb*, as in Nexus 4 port
+
 * Wed Oct 15 2014 Basil Semuonov <basil.semuonov@gmail.com> 0.6-20
 - Fix interval selection on data pages
 

--- a/rpm/harbour-systemmonitor.spec
+++ b/rpm/harbour-systemmonitor.spec
@@ -14,7 +14,7 @@ Name:       harbour-systemmonitor
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    System Monitor
 Version:    0.6
-Release:    20
+Release:    22
 Group:      Qt/Qt
 License:    LICENSE
 URL:        http://thecust.net/

--- a/rpm/harbour-systemmonitor.spec
+++ b/rpm/harbour-systemmonitor.spec
@@ -27,6 +27,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(keepalive)
+BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  desktop-file-utils
 
 %description


### PR DESCRIPTION
This pull request includes several changes introduced into SysMon that I made while following SFOS port in Nexus 4 (mako). While I wanted to split this request into two, they got intermingled due to one commit. So, I'll submit all the changes together for your review.

Changes related to cellular traffic: app/qml/pages/CellPage.qml and daemon/datasourcecell.cpp

In Nexus 4 SFOS port (and probably some others), cell traffic is reported via rmnet_usb devices. As a result, original code ignored this traffic. Code has been changed to pull traffic info only from available files. This can potentially BREAK things if these files/dirs are created dynamically after SysMon daemon start. However, I am unaware of such possibility in practice.

Changes in all other files:

To debug battery charge consumption, I introduced the following changes:
1. I added new CPU sleep data stream that is calculated using the difference in  CLOCK_BOOTTIME and CLOCK_MONOTONIC. This difference shows the amount of time CPU is in sleep (used by mcetool). By recording relative change in clock times, we can get how much time CPU was in sleep between two measurements. In Nexus 4, that would be between 0 (no sleep) and 98% (only 2% time active) in some conditions. Since its directly related to battery, I added plot as a part of battery detailed information.
2. I added plotting of battery charge rates (charge and discharge) as a part of battery detailed plot. Since the rates are calculated from battery charge %, no new data source was needed. The rates are calculated in app/systemmonitor.cpp when dataDerivative property of app/qml/pages/SysMonGraph.qml is set to true. The rates are calculated by hour (3600 s). While for charging autoscale of a plot seems reasonable and other settings can be specified in advance, I found that discharging rates could be interesting to study with different settings. Namely, the patch allows user to specify for discharge rate: maximal Y axis value, minimal time between data points used to calculate the rate, minimal changes in values when calculating the rate. The reasonable defaults are provided, user choices are saved as a part of configuration. User can change the parameters by clicking on discharge rate graph.

I have found that these changes helped me to find problems with faster than expected battery discharge. I expect that these would be useful for others as well. 
